### PR TITLE
EIP-2: Updating jdbc driver & default 'spring.openmrs-datasource.*' to be 'root'

### DIFF
--- a/distribution/springboot_setup/receiver/_application.properties
+++ b/distribution/springboot_setup/receiver/_application.properties
@@ -18,9 +18,9 @@ spring.openmrs-datasource.ddlAuto=none
 # Url of the openMRS datasource
 spring.openmrs-datasource.jdbcUrl=jdbc:mysql://localhost:3306/openmrs
 # User name of the openMRS datasource
-spring.openmrs-datasource.username=openmrs
+spring.openmrs-datasource.username=root
 # Password of the openMRS datasource
-spring.openmrs-datasource.password=openmrs
+spring.openmrs-datasource.password=root
 
 # JPA configuration
 # THIS CONFIGURATION SHOULD NOT BE MODIFIED

--- a/distribution/springboot_setup/receiver/_application.properties
+++ b/distribution/springboot_setup/receiver/_application.properties
@@ -10,7 +10,7 @@ spring.artemis.password=password
 
 # Configuration of the openMRS database to read from
 # Driver class of the openMRS datasource (should not be changed in a usual use)
-spring.openmrs-datasource.driverClassName=com.mysql.jdbc.Driver
+spring.openmrs-datasource.driverClassName=com.mysql.cj.jdbc.Driver
 # Dialect of the openMRS datasource (should not be changed in a usual use)
 spring.openmrs-datasource.dialect=org.hibernate.dialect.MySQLDialect
 # DON'T CHANGE THIS PROPERTY

--- a/distribution/springboot_setup/sender/_application.properties
+++ b/distribution/springboot_setup/sender/_application.properties
@@ -28,9 +28,9 @@ spring.openmrs-datasource.ddlAuto=none
 # Url of the openMRS datasource
 spring.openmrs-datasource.jdbcUrl=jdbc:mysql://${openmrs.db.host}:${openmrs.db.port}/${openmrs.db.name}
 # User name of the openMRS datasource
-spring.openmrs-datasource.username=openmrs
+spring.openmrs-datasource.username=root
 # Password of the openMRS datasource
-spring.openmrs-datasource.password=openmrs
+spring.openmrs-datasource.password=root
 
 # JPA configuration
 # THIS CONFIGURATION SHOULD NOT BE MODIFIED

--- a/distribution/springboot_setup/sender/_application.properties
+++ b/distribution/springboot_setup/sender/_application.properties
@@ -20,7 +20,7 @@ openmrs.db.port=3307
 openmrs.db.name=openmrs
 
 # Driver class of the openMRS datasource (should not be changed in a usual use)
-spring.openmrs-datasource.driverClassName=com.mysql.jdbc.Driver
+spring.openmrs-datasource.driverClassName=com.mysql.cj.jdbc.Driver
 # Dialect of the openMRS datasource (should not be changed in a usual use)
 spring.openmrs-datasource.dialect=org.hibernate.dialect.MySQLDialect
 # DON'T CHANGE THIS PROPERTY


### PR DESCRIPTION
Ticket: https://issues.openmrs.org/browse/EIP-2