### PR TITLE
EIP-133: camelCased datasource property name + improved `executeLiquibase` method signature.

### DIFF
--- a/commons/src/test/java/org/openmrs/eip/BaseDbBackedCamelTest.java
+++ b/commons/src/test/java/org/openmrs/eip/BaseDbBackedCamelTest.java
@@ -43,7 +43,7 @@ public abstract class BaseDbBackedCamelTest extends BaseCamelTest {
 	
 	@DynamicPropertySource
 	static void setProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.openmrs-datasource.jdbc-url", () -> container.getJdbcUrl() + "?useSSL=false&mode=MySQL");
+		registry.add("spring.openmrs-datasource.jdbcUrl", () -> container.getJdbcUrl() + "?useSSL=false&mode=MySQL");
 		registry.add("spring.openmrs-datasource.username", container::getUsername);
 		registry.add("spring.openmrs-datasource.password", container::getPassword);
 		registry.add("spring.openmrs-datasource.driverClassName", container::getDriverClassName);

--- a/commons/src/test/java/org/openmrs/eip/SharedMysqlContainer.java
+++ b/commons/src/test/java/org/openmrs/eip/SharedMysqlContainer.java
@@ -55,19 +55,18 @@ public class SharedMysqlContainer extends MySQLContainer<SharedMysqlContainer> {
 		container.withDatabaseName("openmrs");
 		container.withCopyFileToContainer(forClasspathResource("my.cnf"), "/etc/mysql/my.cnf");
 		super.start();
-		executeLiquibase();
+		executeLiquibase("liquibase-openmrs-test.xml");
 		executeScripts();
 	}
 	
-	private void executeLiquibase() {
+	public void executeLiquibase(String changeLogFile) {
 		try (Connection connection = DriverManager.getConnection(container.getJdbcUrl(), container.getUsername(),
 		    container.getPassword())) {
 			
 			Database database = DatabaseFactory.getInstance()
 			        .findCorrectDatabaseImplementation(new JdbcConnection(connection));
 			
-			Liquibase liquibase = new liquibase.Liquibase("liquibase-openmrs-test.xml", new ClassLoaderResourceAccessor(),
-			        database);
+			Liquibase liquibase = new liquibase.Liquibase(changeLogFile, new ClassLoaderResourceAccessor(), database);
 			
 			CommandScope updateCommand = new CommandScope(UpdateCommandStep.COMMAND_NAME);
 			updateCommand.addArgumentValue(DbUrlConnectionCommandStep.DATABASE_ARG, database);


### PR DESCRIPTION
A follow up PR, that introduces the following changes:
- Renamed `spring.openmrs-datasource.jdbc-url` to `spring.openmrs-datasource.jdbcUrl` for consistency.
- Changed the access of the method `executeLiquibase()` from private to public, now allowing it to accept `changeLogFile` parameter for more versatile execution.