### PR TITLE
Maintain a consistent version of `org.apache.kafka:connect-runtime`.

### DIFF
--- a/openmrs-watcher/pom.xml
+++ b/openmrs-watcher/pom.xml
@@ -13,6 +13,10 @@
     <name>OpenMRS EIP Watcher</name>
     <description>Watches for events from an OpenMRS MySQL database</description>
 
+    <properties>
+        <kakfaConnnectRuntimeVersion>3.4.1</kakfaConnnectRuntimeVersion>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.parent.groupId}</groupId>
@@ -27,6 +31,21 @@
                 <exclusion>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter</artifactId>
+                </exclusion>
+                 <exclusion>
+                     <groupId>org.apache.kafka</groupId>
+                     <artifactId>connect-runtime</artifactId>
+                 </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-runtime</artifactId>
+            <version>${kakfaConnnectRuntimeVersion}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/openmrs-watcher/pom.xml
+++ b/openmrs-watcher/pom.xml
@@ -47,6 +47,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.reload4j</groupId>
+                    <artifactId>reload4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
The `connect-runtime` dependency is obtained transitively and it was observed that the versions at compile time and runtime were inconsistent. This inconsistency can lead to unexpected behavior or runtime errors due to the use of methods(logic) that may not be available in both versions. To resolve this issue, this PR specifies the version of `connect-runtime` explicitly in the pom.xml file of the `openmrs-watcher` module.