### PR TITLE
OZ-563: Disable parallel processing in OpenmrsFhirRouter.

### DIFF
--- a/openmrs-fhir/src/main/java/org/openmrs/eip/fhir/routes/OpenmrsFhirRouter.java
+++ b/openmrs-fhir/src/main/java/org/openmrs/eip/fhir/routes/OpenmrsFhirRouter.java
@@ -49,6 +49,6 @@ public class OpenmrsFhirRouter extends RouteBuilder {
 		        .filter(and(simple("${exchangeProperty." + PROP_EVENT_SNAPSHOT + "}").isEqualTo(false),
 		            simple("${exchangeProperty." + PROP_EVENT_TABLE_NAME + "}").in((Object[]) monitoredTables)))
 		        .log(LoggingLevel.INFO, "Dispatching to endpoints " + resourceDestinations)
-		        .recipientList(constant(resourceDestinations)).parallelProcessing().end();
+		        .recipientList(constant(resourceDestinations)).synchronous(true).end();
 	}
 }


### PR DESCRIPTION
This PR modifies the OpenmrsFhirRouter's recipient list processing to be synchronous. The `.synchronous(true)` method call ensures that the recipient list processes messages in a synchronous manner. This change is intended to improve the control over the order and timing of message processing.