### PR TITLE
OZ-669: Add `WatcherInitRoute` to `openmrs-watcher` module

### DIFF
--- a/openmrs-watcher/src/main/java/org/openmrs/eip/mysql/watcher/route/WatcherInitRoute.java
+++ b/openmrs-watcher/src/main/java/org/openmrs/eip/mysql/watcher/route/WatcherInitRoute.java
@@ -1,0 +1,18 @@
+package org.openmrs.eip.mysql.watcher.route;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.springframework.stereotype.Component;
+
+/**
+ * This route is used to initialize the OpenMRS watcher. It is only used once when the application
+ * starts up.
+ */
+@Component
+public class WatcherInitRoute extends RouteBuilder {
+	
+	@Override
+	public void configure() {
+		from("scheduler:openmrs-watcher?initialDelay=500&repeatCount=1").routeId("openmrs-watcher-init-route")
+		        .to("openmrs-watcher:init").end();
+	}
+}

--- a/openmrs-watcher/src/test/java/org/openmrs/eip/mysql/watcher/route/WatcherInitRouteTest.java
+++ b/openmrs-watcher/src/test/java/org/openmrs/eip/mysql/watcher/route/WatcherInitRouteTest.java
@@ -1,0 +1,50 @@
+package org.openmrs.eip.mysql.watcher.route;
+
+import static org.apache.camel.builder.AdviceWith.adviceWith;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.spring.junit5.MockEndpoints;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.annotation.DirtiesContext;
+
+@MockEndpoints
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class WatcherInitRouteTest extends BaseWatcherRouteTest {
+	
+	@EndpointInject("mock:init")
+	private MockEndpoint mockInit;
+	
+	@BeforeEach
+	public void setup() throws Exception {
+		mockInit.reset();
+		
+		camelContext.addRoutes(new WatcherInitRoute());
+		
+		adviceWith(camelContext, "openmrs-watcher-init-route", route -> {
+			route.replaceFromWith("direct:start");
+			route.weaveByToUri("openmrs-watcher:init").replace().to("mock:init");
+		});
+	}
+	
+	@Test
+	public void shouldInitializeOpenmrsWatcherRoute() throws Exception {
+		// Arrange
+		mockInit.expectedMessageCount(1);
+		
+		// Act
+		ProducerTemplate template = camelContext.createProducerTemplate();
+		template.sendBody("direct:start", null);
+		
+		// Assert
+		mockInit.assertIsSatisfied();
+	}
+	
+	@Test
+	public void shouldRegisteredOpenmrsInitRoute() {
+		assertNotNull(camelContext.getRoute("openmrs-watcher-init-route"));
+	}
+}


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/browse/OZ-669

I believe `WatcherInitRoute` belongs within the `openmrs-watcher` module. Every time we create a project depending on `openmrs-watcher`, we need to add this route to trigger the watcher. To me, it's redundant, and we should already have it here.