### PR TITLE
OZ-942: Add clock skew support to `TokenCache`

### DIFF
--- a/camel-openmrs-fhir/src/main/java/org/openmrs/eip/fhir/security/OpenmrsFhirOauth2.java
+++ b/camel-openmrs-fhir/src/main/java/org/openmrs/eip/fhir/security/OpenmrsFhirOauth2.java
@@ -6,6 +6,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Base64;
 
+import lombok.Getter;
 import org.openmrs.eip.EIPException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -26,6 +27,10 @@ public class OpenmrsFhirOauth2 {
 	
 	@Value("${oauth.client.scope}")
 	private String scope;
+	
+	@Value("${oauth.token.clock.skew:30}")
+	@Getter
+	private int clockSkewSeconds;
 	
 	public static final String HTTP_AUTH_SCHEME = "Bearer";
 	

--- a/camel-openmrs-fhir/src/main/java/org/openmrs/eip/fhir/security/OpenmrsFhirOauth2.java
+++ b/camel-openmrs-fhir/src/main/java/org/openmrs/eip/fhir/security/OpenmrsFhirOauth2.java
@@ -6,12 +6,13 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Base64;
 
-import lombok.Getter;
 import org.openmrs.eip.EIPException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.Getter;
 
 @Component
 public class OpenmrsFhirOauth2 {

--- a/camel-openmrs-fhir/src/main/java/org/openmrs/eip/fhir/security/TokenCache.java
+++ b/camel-openmrs-fhir/src/main/java/org/openmrs/eip/fhir/security/TokenCache.java
@@ -5,44 +5,47 @@ import org.springframework.stereotype.Component;
 
 @Component("tokenCache")
 public class TokenCache {
-	
-	@Autowired
-	private OpenmrsFhirOauth2 openmrsFhirOauth2;
-	
-	private TokenInfo tokenInfo;
-	
-	private long expiryTime;
-	
-	public TokenCache() {
-	}
-	
-	public void setTokenInfo(TokenInfo tokenInfo) {
-		this.tokenInfo = tokenInfo;
-	}
-	
-	public void setExpiryTime(long expiryTime) {
-		this.expiryTime = expiryTime;
-	}
-	
-	/**
-	 * Fetches the token info from the Oauth server if it is not already cached or if it has expired
-	 *
-	 * @return the token info
-	 */
-	public TokenInfo getTokenInfo() {
-		if (tokenInfo == null || isTokenExpired()) {
-			this.tokenInfo = openmrsFhirOauth2.fetchTokenInfo();
-			this.setExpiryTime((System.currentTimeMillis() + Long.parseLong(tokenInfo.getExpiresIn()) * 1000));
-		}
-		return tokenInfo;
-	}
-	
-	/**
-	 * Checks if the token has expired
-	 *
-	 * @return true if the token has expired
-	 */
-	boolean isTokenExpired() {
-		return System.currentTimeMillis() > expiryTime;
-	}
+
+    @Autowired
+    private OpenmrsFhirOauth2 openmrsFhirOauth2;
+
+    private TokenInfo tokenInfo;
+    private long expiryTime;
+
+    public TokenCache() {
+    }
+
+    public void setTokenInfo(TokenInfo tokenInfo) {
+        this.tokenInfo = tokenInfo;
+    }
+
+    public void setExpiryTime(long expiryTime) {
+        this.expiryTime = expiryTime;
+    }
+
+    /**
+     * Fetches the token info from the Oauth server if it is not already cached or if it has expired
+     *
+     * @return the token info
+     */
+    public TokenInfo getTokenInfo() {
+        if (tokenInfo == null || shouldRefreshToken()) {
+            this.tokenInfo = openmrsFhirOauth2.fetchTokenInfo();
+            this.setExpiryTime(calculateExpiryTime());
+        }
+        return tokenInfo;
+    }
+
+    /**
+     * Checks if the token should be refreshed based on expiry time and clock skew
+     *
+     * @return true if the token should be refreshed
+     */
+    boolean shouldRefreshToken() {
+        return System.currentTimeMillis() > (expiryTime - (openmrsFhirOauth2.getClockSkewSeconds() * 1000L));
+    }
+
+    private long calculateExpiryTime() {
+        return System.currentTimeMillis() + (Long.parseLong(tokenInfo.getExpiresIn()) * 1000);
+    }
 }

--- a/camel-openmrs-fhir/src/main/java/org/openmrs/eip/fhir/security/TokenCache.java
+++ b/camel-openmrs-fhir/src/main/java/org/openmrs/eip/fhir/security/TokenCache.java
@@ -5,47 +5,48 @@ import org.springframework.stereotype.Component;
 
 @Component("tokenCache")
 public class TokenCache {
-
-    @Autowired
-    private OpenmrsFhirOauth2 openmrsFhirOauth2;
-
-    private TokenInfo tokenInfo;
-    private long expiryTime;
-
-    public TokenCache() {
-    }
-
-    public void setTokenInfo(TokenInfo tokenInfo) {
-        this.tokenInfo = tokenInfo;
-    }
-
-    public void setExpiryTime(long expiryTime) {
-        this.expiryTime = expiryTime;
-    }
-
-    /**
-     * Fetches the token info from the Oauth server if it is not already cached or if it has expired
-     *
-     * @return the token info
-     */
-    public TokenInfo getTokenInfo() {
-        if (tokenInfo == null || shouldRefreshToken()) {
-            this.tokenInfo = openmrsFhirOauth2.fetchTokenInfo();
-            this.setExpiryTime(calculateExpiryTime());
-        }
-        return tokenInfo;
-    }
-
-    /**
-     * Checks if the token should be refreshed based on expiry time and clock skew
-     *
-     * @return true if the token should be refreshed
-     */
-    boolean shouldRefreshToken() {
-        return System.currentTimeMillis() > (expiryTime - (openmrsFhirOauth2.getClockSkewSeconds() * 1000L));
-    }
-
-    private long calculateExpiryTime() {
-        return System.currentTimeMillis() + (Long.parseLong(tokenInfo.getExpiresIn()) * 1000);
-    }
+	
+	@Autowired
+	private OpenmrsFhirOauth2 openmrsFhirOauth2;
+	
+	private TokenInfo tokenInfo;
+	
+	private long expiryTime;
+	
+	public TokenCache() {
+	}
+	
+	public void setTokenInfo(TokenInfo tokenInfo) {
+		this.tokenInfo = tokenInfo;
+	}
+	
+	public void setExpiryTime(long expiryTime) {
+		this.expiryTime = expiryTime;
+	}
+	
+	/**
+	 * Fetches the token info from the Oauth server if it is not already cached or if it has expired
+	 *
+	 * @return the token info
+	 */
+	public TokenInfo getTokenInfo() {
+		if (tokenInfo == null || shouldRefreshToken()) {
+			this.tokenInfo = openmrsFhirOauth2.fetchTokenInfo();
+			this.setExpiryTime(calculateExpiryTime());
+		}
+		return tokenInfo;
+	}
+	
+	/**
+	 * Checks if the token should be refreshed based on expiry time and clock skew
+	 *
+	 * @return true if the token should be refreshed
+	 */
+	boolean shouldRefreshToken() {
+		return System.currentTimeMillis() > (expiryTime - (openmrsFhirOauth2.getClockSkewSeconds() * 1000L));
+	}
+	
+	private long calculateExpiryTime() {
+		return System.currentTimeMillis() + (Long.parseLong(tokenInfo.getExpiresIn()) * 1000);
+	}
 }

--- a/camel-openmrs-fhir/src/test/java/org/openmrs/eip/fhir/security/OpenmrsFhirOauth2Test.java
+++ b/camel-openmrs-fhir/src/test/java/org/openmrs/eip/fhir/security/OpenmrsFhirOauth2Test.java
@@ -35,6 +35,7 @@ public class OpenmrsFhirOauth2Test {
 		setField(openmrsFhirOauth2, "clientId", "client");
 		setField(openmrsFhirOauth2, "clientSecret", "secret");
 		setField(openmrsFhirOauth2, "scope", "openid");
+		setField(openmrsFhirOauth2, "clockSkewSeconds", 30);
 		openmrsFhirOauth2.setHttpClient(httpClient);
 	}
 	
@@ -96,5 +97,12 @@ public class OpenmrsFhirOauth2Test {
 		setField(openmrsFhirOauth2, "oauthUri", null);
 		
 		assertThrows(IllegalStateException.class, () -> openmrsFhirOauth2.validateOAuthConfig());
+	}
+	
+	@Test
+	@DisplayName("Should return default clock skew seconds.")
+	void shouldReturnDefaultClockSkewSeconds() {
+		int defaultClockSkew = openmrsFhirOauth2.getClockSkewSeconds();
+		assertEquals(30, defaultClockSkew, "Default clock skew seconds should be 30");
 	}
 }

--- a/camel-openmrs-fhir/src/test/java/org/openmrs/eip/fhir/security/TokenCacheTest.java
+++ b/camel-openmrs-fhir/src/test/java/org/openmrs/eip/fhir/security/TokenCacheTest.java
@@ -90,4 +90,34 @@ class TokenCacheTest {
 		assertEquals(tokenInfo, result);
 		verify(openmrsFhirOauth2, never()).fetchTokenInfo();
 	}
+	
+	@Test
+	@DisplayName("Should fetch new token when within clock skew window")
+	void shouldFetchNewTokenWhenWithinClockSkewWindow() {
+		int clockSkewSeconds = 30;
+		when(openmrsFhirOauth2.getClockSkewSeconds()).thenReturn(clockSkewSeconds);
+		
+		TokenInfo oldToken = new TokenInfo();
+		oldToken.setExpiresIn("3600");
+		oldToken.setAccessToken("oldToken");
+		oldToken.setTokenType("Bearer");
+		
+		// Set expiry time to 20 seconds from now (within clock skew window)
+		long expiryTime = System.currentTimeMillis() + 20_000;
+		tokenCache.setTokenInfo(oldToken);
+		tokenCache.setExpiryTime(expiryTime);
+		
+		TokenInfo newToken = new TokenInfo();
+		newToken.setExpiresIn("3600");
+		newToken.setAccessToken("newToken");
+		newToken.setTokenType("Bearer");
+		when(openmrsFhirOauth2.fetchTokenInfo()).thenReturn(newToken);
+		
+		TokenInfo result = tokenCache.getTokenInfo();
+		
+		assertEquals(newToken, result);
+		// Verify that fetchTokenInfo & getClockSkewSeconds were called
+		verify(openmrsFhirOauth2).fetchTokenInfo();
+		verify(openmrsFhirOauth2).getClockSkewSeconds();
+	}
 }

--- a/camel-openmrs-fhir/src/test/java/org/openmrs/eip/fhir/security/TokenCacheTest.java
+++ b/camel-openmrs-fhir/src/test/java/org/openmrs/eip/fhir/security/TokenCacheTest.java
@@ -92,30 +92,30 @@ class TokenCacheTest {
 	}
 	
 	@Test
-	@DisplayName("Should fetch new token when within clock skew window")
+	@DisplayName("Should fetch new token when within clock skew window.")
 	void shouldFetchNewTokenWhenWithinClockSkewWindow() {
-		int clockSkewSeconds = 30;
-		when(openmrsFhirOauth2.getClockSkewSeconds()).thenReturn(clockSkewSeconds);
+		when(openmrsFhirOauth2.getClockSkewSeconds()).thenReturn(30);
 		
-		TokenInfo oldToken = new TokenInfo();
+		TokenInfo oldToken=new TokenInfo();
 		oldToken.setExpiresIn("3600");
 		oldToken.setAccessToken("oldToken");
 		oldToken.setTokenType("Bearer");
 		
 		// Set expiry time to 20 seconds from now (within clock skew window)
-		long expiryTime = System.currentTimeMillis() + 20_000;
+		long expiryTime=System.currentTimeMillis() + 20_000;
 		tokenCache.setTokenInfo(oldToken);
 		tokenCache.setExpiryTime(expiryTime);
 		
-		TokenInfo newToken = new TokenInfo();
+		TokenInfo newToken=new TokenInfo();
 		newToken.setExpiresIn("3600");
 		newToken.setAccessToken("newToken");
 		newToken.setTokenType("Bearer");
+		
 		when(openmrsFhirOauth2.fetchTokenInfo()).thenReturn(newToken);
 		
-		TokenInfo result = tokenCache.getTokenInfo();
+		TokenInfo result=tokenCache.getTokenInfo();
 		
-		assertEquals(newToken, result);
+		assertEquals(newToken,result);
 		// Verify that fetchTokenInfo & getClockSkewSeconds were called
 		verify(openmrsFhirOauth2).fetchTokenInfo();
 		verify(openmrsFhirOauth2).getClockSkewSeconds();


### PR DESCRIPTION
This PR adds clock skew support to `TokenCache` to handle system time differences and prevent JWT expiration errors. The implementation allows for a configurable clock skew window (default 30 seconds) that determines when tokens should be refreshed before their actual expiration.

Fixes issue with JWT expiration errors due to small time differences between systems