### PR TITLE
TRUNK-6640: Add Spring leader election for Debezium

### DIFF
--- a/camel-openmrs-fhir/src/generated/resources/org/openmrs/eip/fhir/components/openmrs-fhir.json
+++ b/camel-openmrs-fhir/src/generated/resources/org/openmrs/eip/fhir/components/openmrs-fhir.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "org.openmrs.eip",
     "artifactId": "camel-openmrs-fhir",
-    "version": "4.2.0-SNAPSHOT",
+    "version": "4.3.0-SNAPSHOT",
     "scheme": "openmrs-fhir",
     "extendsScheme": "",
     "syntax": "openmrs-fhir:\/\/name",

--- a/commons/src/test/java/org/openmrs/eip/BaseDbBackedCamelTest.java
+++ b/commons/src/test/java/org/openmrs/eip/BaseDbBackedCamelTest.java
@@ -2,6 +2,8 @@ package org.openmrs.eip;
 
 import javax.sql.DataSource;
 
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
 import org.openmrs.eip.config.DatasourceConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -11,6 +13,7 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.SqlScriptsTestExecutionListener;
+import org.testcontainers.DockerClientFactory;
 
 /**
  * Base class for tests for routes that require access to the management and OpenMRS databases.
@@ -30,8 +33,12 @@ public abstract class BaseDbBackedCamelTest extends BaseCamelTest {
 	
 	protected static SharedMysqlContainer container = SharedMysqlContainer.getInstance();
 	
-	static {
-		container.start();
+	@BeforeAll
+	public static void beforeAllBaseDbBackedCamelTest() {
+		Assumptions.assumeTrue(DockerClientFactory.instance().isDockerAvailable(), "Docker is not available");
+		if (!container.isRunning()) {
+			container.start();
+		}
 	}
 	
 	@Autowired
@@ -44,12 +51,14 @@ public abstract class BaseDbBackedCamelTest extends BaseCamelTest {
 	
 	@DynamicPropertySource
 	static void setProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.openmrs-datasource.jdbcUrl", () -> container.getJdbcUrl() + "?useSSL=false&MODE=MySQL");
-		registry.add("spring.openmrs-datasource.username", container::getUsername);
-		registry.add("spring.openmrs-datasource.password", container::getPassword);
-		registry.add("spring.openmrs-datasource.driverClassName", container::getDriverClassName);
-		registry.add("openmrs.db.port", () -> container.getMappedPort(3306));
-		registry.add("openmrs.db.host", container::getHost);
-		registry.add("openmrs.db.name", container::getDatabaseName);
+		if (DockerClientFactory.instance().isDockerAvailable()) {
+			registry.add("spring.openmrs-datasource.jdbcUrl", () -> container.getJdbcUrl() + "?useSSL=false&MODE=MySQL");
+			registry.add("spring.openmrs-datasource.username", container::getUsername);
+			registry.add("spring.openmrs-datasource.password", container::getPassword);
+			registry.add("spring.openmrs-datasource.driverClassName", container::getDriverClassName);
+			registry.add("openmrs.db.port", () -> container.getMappedPort(3306));
+			registry.add("openmrs.db.host", container::getHost);
+			registry.add("openmrs.db.name", container::getDatabaseName);
+		}
 	}
 }

--- a/commons/src/test/java/org/openmrs/eip/SharedMysqlContainer.java
+++ b/commons/src/test/java/org/openmrs/eip/SharedMysqlContainer.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
@@ -51,6 +52,11 @@ public class SharedMysqlContainer extends MySQLContainer<SharedMysqlContainer> {
 	
 	@Override
 	public void start() {
+		if (!DockerClientFactory.instance().isDockerAvailable()) {
+			log.warn("Docker is not available, skipping container start");
+			return;
+		}
+		
 		container.withEnv("MYSQL_ROOT_PASSWORD", "test");
 		container.withDatabaseName("openmrs");
 		container.withCopyFileToContainer(forClasspathResource("my.cnf"), "/etc/mysql/my.cnf");

--- a/openmrs-watcher/pom.xml
+++ b/openmrs-watcher/pom.xml
@@ -64,6 +64,14 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-integration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.integration</groupId>
+            <artifactId>spring-integration-jdbc</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/openmrs-watcher/src/main/java/org/openmrs/eip/mysql/watcher/MySqlWatcherProducer.java
+++ b/openmrs-watcher/src/main/java/org/openmrs/eip/mysql/watcher/MySqlWatcherProducer.java
@@ -1,5 +1,8 @@
 package org.openmrs.eip.mysql.watcher;
 
+import static org.openmrs.eip.mysql.watcher.WatcherConstants.DEBEZIUM_ROUTE_ID;
+import static org.openmrs.eip.mysql.watcher.WatcherConstants.PROP_LEADER_ELECTION_ENABLED;
+
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.support.DefaultProducer;
@@ -35,8 +38,15 @@ public class MySqlWatcherProducer extends DefaultProducer {
 	@Override
 	public void process(Exchange exchange) throws Exception {
 		logger.info("Registering debezium route");
+		boolean leaderElectionEnabled = exchange.getContext()
+		        .resolvePropertyPlaceholders("{{" + PROP_LEADER_ELECTION_ENABLED + ":false}}").equalsIgnoreCase("true");
 		
-		exchange.getContext().addRoutes(new DebeziumRoute(DEBEZIUM_FROM_URI, WatcherConstants.SHUTDOWN_HANDLER_REF));
+		exchange.getContext().addRoutes(
+		    new DebeziumRoute(DEBEZIUM_FROM_URI, WatcherConstants.SHUTDOWN_HANDLER_REF, !leaderElectionEnabled));
+		
+		if (leaderElectionEnabled) {
+			WatcherLeaderListener.onRouteRegistered(exchange.getContext());
+		}
 	}
 	
 }

--- a/openmrs-watcher/src/main/java/org/openmrs/eip/mysql/watcher/WatcherConstants.java
+++ b/openmrs-watcher/src/main/java/org/openmrs/eip/mysql/watcher/WatcherConstants.java
@@ -54,4 +54,6 @@ public class WatcherConstants {
 	
 	public static final String PROP_AUDIT_FILTER_TABLES = "filter.auditable.tables";
 	
+	public static final String PROP_LEADER_ELECTION_ENABLED = "watcher.leader.election.enabled";
+	
 }

--- a/openmrs-watcher/src/main/java/org/openmrs/eip/mysql/watcher/WatcherLeaderListener.java
+++ b/openmrs-watcher/src/main/java/org/openmrs/eip/mysql/watcher/WatcherLeaderListener.java
@@ -1,0 +1,99 @@
+package org.openmrs.eip.mysql.watcher;
+
+import static org.openmrs.eip.mysql.watcher.WatcherConstants.DEBEZIUM_ROUTE_ID;
+import static org.openmrs.eip.mysql.watcher.WatcherConstants.PROP_LEADER_ELECTION_ENABLED;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Route;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.event.EventListener;
+import org.springframework.integration.leader.event.OnGrantedEvent;
+import org.springframework.integration.leader.event.OnRevokedEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(name = PROP_LEADER_ELECTION_ENABLED, havingValue = "true")
+public class WatcherLeaderListener {
+	
+	private static final Logger logger = LoggerFactory.getLogger(WatcherLeaderListener.class);
+	
+	private static final AtomicBoolean leader = new AtomicBoolean();
+	
+	private static final Object LOCK = new Object();
+	
+	private CamelContext camelContext;
+	
+	public WatcherLeaderListener(CamelContext camelContext) {
+		this.camelContext = camelContext;
+	}
+	
+	/**
+	 * Checks if this instance is the leader.
+	 * 
+	 * @return true if leader otherwise false
+	 */
+	public static boolean isLeader() {
+		return leader.get();
+	}
+	
+	/**
+	 * Resets the leader status to false, should only be called by tests.
+	 */
+	protected static void reset() {
+		leader.set(false);
+	}
+	
+	@EventListener
+	public void onGranted(OnGrantedEvent event) throws Exception {
+		synchronized (LOCK) {
+			logger.info("Leadership granted, starting debezium route");
+			leader.set(true);
+			startRoute(camelContext);
+		}
+	}
+	
+	@EventListener
+	public void onRevoked(OnRevokedEvent event) throws Exception {
+		synchronized (LOCK) {
+			logger.info("Leadership revoked, stopping debezium route");
+			leader.set(false);
+			stopRoute(camelContext);
+		}
+	}
+	
+	/**
+	 * Should be called when the debezium route is registered to start it if leadership was already
+	 * granted.
+	 * 
+	 * @param camelContext the CamelContext
+	 */
+	public static void onRouteRegistered(CamelContext camelContext) throws Exception {
+		synchronized (LOCK) {
+			if (leader.get()) {
+				logger.info("Leadership already granted, starting debezium route");
+				startRoute(camelContext);
+			}
+		}
+	}
+	
+	private static void startRoute(CamelContext camelContext) throws Exception {
+		Route route = camelContext.getRoute(DEBEZIUM_ROUTE_ID);
+		if (route != null) {
+			camelContext.getRouteController().startRoute(DEBEZIUM_ROUTE_ID);
+		} else {
+			logger.warn("Debezium route not found, it might not have been registered yet");
+		}
+	}
+	
+	private static void stopRoute(CamelContext camelContext) throws Exception {
+		Route route = camelContext.getRoute(DEBEZIUM_ROUTE_ID);
+		if (route != null) {
+			camelContext.getRouteController().stopRoute(DEBEZIUM_ROUTE_ID);
+		}
+	}
+	
+}

--- a/openmrs-watcher/src/main/java/org/openmrs/eip/mysql/watcher/config/LeaderElectionConfig.java
+++ b/openmrs-watcher/src/main/java/org/openmrs/eip/mysql/watcher/config/LeaderElectionConfig.java
@@ -1,0 +1,36 @@
+package org.openmrs.eip.mysql.watcher.config;
+
+import static org.openmrs.eip.mysql.watcher.WatcherConstants.PROP_LEADER_ELECTION_ENABLED;
+
+import javax.sql.DataSource;
+
+import org.openmrs.eip.Constants;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.jdbc.lock.DefaultLockRepository;
+import org.springframework.integration.jdbc.lock.JdbcLockRegistry;
+import org.springframework.integration.jdbc.lock.LockRepository;
+import org.springframework.integration.support.leader.LockRegistryLeaderInitiator;
+
+@Configuration
+@ConditionalOnProperty(name = PROP_LEADER_ELECTION_ENABLED, havingValue = "true")
+public class LeaderElectionConfig {
+	
+	@Bean
+	public LockRepository lockRepository(@Qualifier(Constants.MGT_DATASOURCE_NAME) DataSource dataSource) {
+		return new DefaultLockRepository(dataSource);
+	}
+	
+	@Bean
+	public JdbcLockRegistry lockRegistry(LockRepository lockRepository) {
+		return new JdbcLockRegistry(lockRepository);
+	}
+	
+	@Bean
+	public LockRegistryLeaderInitiator leaderInitiator(JdbcLockRegistry lockRegistry) {
+		return new LockRegistryLeaderInitiator(lockRegistry);
+	}
+	
+}

--- a/openmrs-watcher/src/main/java/org/openmrs/eip/mysql/watcher/route/DebeziumRoute.java
+++ b/openmrs-watcher/src/main/java/org/openmrs/eip/mysql/watcher/route/DebeziumRoute.java
@@ -31,9 +31,12 @@ public class DebeziumRoute extends RouteBuilder {
 	
 	private String errorHandlerRef;
 	
-	public DebeziumRoute(String fromUri, String errorHandlerRef) {
+	private boolean autoStartup;
+	
+	public DebeziumRoute(String fromUri, String errorHandlerRef, boolean autoStartup) {
 		this.fromUri = fromUri;
 		this.errorHandlerRef = errorHandlerRef;
+		this.autoStartup = autoStartup;
 	}
 	
 	@Override
@@ -41,6 +44,11 @@ public class DebeziumRoute extends RouteBuilder {
 		logger.info("Starting debezium...");
 		
 		RouteDefinition routeDef = from(fromUri).routeId(DEBEZIUM_ROUTE_ID);
+		
+		if (!autoStartup) {
+			logger.info("Debezium route will not auto start");
+			routeDef.autoStartup(false);
+		}
 		
 		logger.info("Setting debezium route error handler to: " + errorHandlerRef);
 		

--- a/openmrs-watcher/src/main/resources/liquibase-watcher.xml
+++ b/openmrs-watcher/src/main/resources/liquibase-watcher.xml
@@ -124,6 +124,30 @@
         </createTable>
     </changeSet>
 
+    <changeSet author="openmrs" id="20240410-1000">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="INT_LOCK"/>
+            </not>
+        </preConditions>
+        <comment>Adding INT_LOCK table for Spring Integration leader election</comment>
+        <createTable tableName="INT_LOCK">
+            <column name="LOCK_KEY" type="CHAR(36)">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="REGION" type="VARCHAR(100)">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="CLIENT_ID" type="CHAR(36)"/>
+            <column name="CREATED_DATE" type="DATETIME(6)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="EXPIRED_AFTER" type="DATETIME(6)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
     <changeSet author="wluyima" id="20250910-1200">
         <preConditions onFail="MARK_RAN">
             <tableExists tableName="hibernate_sequence"/>

--- a/openmrs-watcher/src/test/java/org/openmrs/eip/mysql/watcher/WatcherLeaderListenerTest.java
+++ b/openmrs-watcher/src/test/java/org/openmrs/eip/mysql/watcher/WatcherLeaderListenerTest.java
@@ -1,0 +1,106 @@
+package org.openmrs.eip.mysql.watcher;
+
+import static org.openmrs.eip.mysql.watcher.WatcherConstants.DEBEZIUM_ROUTE_ID;
+import static org.openmrs.eip.mysql.watcher.WatcherConstants.PROP_LEADER_ELECTION_ENABLED;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Route;
+import org.apache.camel.spi.RouteController;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.integration.leader.event.OnGrantedEvent;
+import org.springframework.integration.leader.event.OnRevokedEvent;
+
+public class WatcherLeaderListenerTest {
+	
+	@Mock
+	private CamelContext mockCamelContext;
+	
+	@Mock
+	private RouteController mockRouteController;
+	
+	@Mock
+	private Route mockRoute;
+	
+	private WatcherLeaderListener listener;
+	
+	@BeforeEach
+	public void setup() {
+		MockitoAnnotations.openMocks(this);
+		listener = new WatcherLeaderListener(mockCamelContext);
+		Mockito.when(mockCamelContext.getRouteController()).thenReturn(mockRouteController);
+		WatcherLeaderListener.reset();
+	}
+	
+	@Test
+	public void onGranted_shouldStartTheDebeziumRouteIfItExists() throws Exception {
+		Mockito.when(mockCamelContext.getRoute(DEBEZIUM_ROUTE_ID)).thenReturn(mockRoute);
+		Assertions.assertFalse(WatcherLeaderListener.isLeader());
+		
+		listener.onGranted(Mockito.mock(OnGrantedEvent.class));
+		
+		Assertions.assertTrue(WatcherLeaderListener.isLeader());
+		Mockito.verify(mockRouteController).startRoute(DEBEZIUM_ROUTE_ID);
+	}
+	
+	@Test
+	public void onGranted_shouldNotStartTheDebeziumRouteIfItDoesNotExist() throws Exception {
+		Mockito.when(mockCamelContext.getRoute(DEBEZIUM_ROUTE_ID)).thenReturn(null);
+		Assertions.assertFalse(WatcherLeaderListener.isLeader());
+		
+		listener.onGranted(Mockito.mock(OnGrantedEvent.class));
+		
+		Assertions.assertTrue(WatcherLeaderListener.isLeader());
+		Mockito.verify(mockRouteController, Mockito.never()).startRoute(Mockito.anyString());
+	}
+	
+	@Test
+	public void onRevoked_shouldStopTheDebeziumRouteIfItExists() throws Exception {
+		Mockito.when(mockCamelContext.getRoute(DEBEZIUM_ROUTE_ID)).thenReturn(mockRoute);
+		// Manually set leader to true
+		listener.onGranted(Mockito.mock(OnGrantedEvent.class));
+		Assertions.assertTrue(WatcherLeaderListener.isLeader());
+		
+		listener.onRevoked(Mockito.mock(OnRevokedEvent.class));
+		
+		Assertions.assertFalse(WatcherLeaderListener.isLeader());
+		Mockito.verify(mockRouteController).stopRoute(DEBEZIUM_ROUTE_ID);
+	}
+	
+	@Test
+	public void onRevoked_shouldNotStopTheDebeziumRouteIfItDoesNotExist() throws Exception {
+		Mockito.when(mockCamelContext.getRoute(DEBEZIUM_ROUTE_ID)).thenReturn(null);
+		// Manually set leader to true
+		listener.onGranted(Mockito.mock(OnGrantedEvent.class));
+		Assertions.assertTrue(WatcherLeaderListener.isLeader());
+		
+		listener.onRevoked(Mockito.mock(OnRevokedEvent.class));
+		
+		Assertions.assertFalse(WatcherLeaderListener.isLeader());
+		Mockito.verify(mockRouteController, Mockito.never()).stopRoute(Mockito.anyString());
+	}
+	
+	@Test
+	public void onRouteRegistered_shouldStartTheDebeziumRouteIfIsLeader() throws Exception {
+		Mockito.when(mockCamelContext.getRoute(DEBEZIUM_ROUTE_ID)).thenReturn(mockRoute);
+		// Manually set leader to true
+		listener.onGranted(Mockito.mock(OnGrantedEvent.class));
+		Mockito.clearInvocations(mockRouteController);
+		
+		WatcherLeaderListener.onRouteRegistered(mockCamelContext);
+		
+		Mockito.verify(mockRouteController).startRoute(DEBEZIUM_ROUTE_ID);
+	}
+	
+	@Test
+	public void onRouteRegistered_shouldNotStartTheDebeziumRouteIfIsNotLeader() throws Exception {
+		WatcherLeaderListener.onRouteRegistered(mockCamelContext);
+		
+		Mockito.verify(mockRouteController, Mockito.never()).startRoute(Mockito.anyString());
+	}
+	
+}

--- a/openmrs-watcher/src/test/java/org/openmrs/eip/mysql/watcher/route/DebeziumRouteTest.java
+++ b/openmrs-watcher/src/test/java/org/openmrs/eip/mysql/watcher/route/DebeziumRouteTest.java
@@ -44,7 +44,7 @@ public class DebeziumRouteTest extends BaseWatcherRouteTest {
 		mockIdSettingEndpoint.reset();
 		mockEventListenerEndpoint.reset();
 		
-		camelContext.addRoutes(new DebeziumRoute(URI, ERROR_HANDLER_REF));
+		camelContext.addRoutes(new DebeziumRoute(URI, ERROR_HANDLER_REF, true));
 		
 		advise(DEBEZIUM_ROUTE_ID, new AdviceWithRouteBuilder() {
 			


### PR DESCRIPTION
**Description of what changed** 
I added a new configuration infrastructure` class LeaderElectionConfig` to register the application instance as a candidate in a synchronization group (e.g., debezium-cluster).

**Issue fixed** 
https://openmrs.atlassian.net/issues?filter=-8&selectedIssue=TRUNK-6640